### PR TITLE
Disable Rust scanning in CodeQL workflow (#33)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,8 +51,8 @@ jobs:
           build-mode: none
         - language: ruby
           build-mode: none
-        - language: rust
-          build-mode: none
+        # Rust scanning disabled - experimental code in ARCHIVE/ has no Cargo.toml
+        # Re-enable when a proper Rust project is added to the repository
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
The experimental Rust code in ARCHIVE/license-parser-experiments/ has no Cargo.toml, causing CodeQL to report 0% call target and macro resolution rates. Since this is archived experimental code without a proper Cargo project, disable Rust scanning until a buildable Rust project is added to the repository.