### PR TITLE
ci(scorecard): add job-level permissions for reusable workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,5 +12,8 @@ permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      id-token: write
     uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
     secrets: inherit


### PR DESCRIPTION
Add job-level `permissions: { security-events: write, id-token: write }` to `jobs.analysis`. Refs hyperpolymath/standards#282