### PR TITLE
fix(ci): add language: actions to codeql.yml matrix (WF020)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,8 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+          - language: actions
+            build-mode: none
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Adds `language: actions` to the CodeQL analysis matrix (WF020 fix).

## Why

The `actions` extractor scans workflow YAML files for CI/CD security weaknesses. Without it, Hypatia flags WF020 on every PR.

## Change

```yaml
matrix:
  include:
    - language: javascript-typescript
      build-mode: none
    - language: actions        # ← added
      build-mode: none         # ← added
```

## Verify-before-merge

- [x] `actionlint` clean
- [x] Commit signed (SSH signing key kVP7)
- [x] CI-config only — no content/license changes

Part of estate-wide WF020 sweep.