### PR TITLE
feat(ci): attest build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     name: Build release artefacts
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -47,6 +51,11 @@ jobs:
             cp tools/pmpl-audit/target/release/pmpl-audit dist/
           fi
           ls -R dist || true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'dist/**'
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2


### PR DESCRIPTION
Estate attestation rollout: add GitHub-native build-provenance attestation (actions/attest-build-provenance@v2, pinned) to the release workflow, attesting the SAME artifacts uploaded by softprops/action-gh-release.

Attested path(s): dist/**

Pinned: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2