### PR TITLE
fix(ci): drop invalid timeout-minutes from reusable-workflow calls (parse-dead)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -32,4 +32,3 @@ permissions:
 jobs:
   governance:
     uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
-    timeout-minutes: 10

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -26,5 +26,4 @@ permissions:
 jobs:
   hypatia:
     uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
-    timeout-minutes: 10
     secrets: inherit

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,5 +12,4 @@ permissions:
 jobs:
   mirror:
     uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
-    timeout-minutes: 10
     secrets: inherit

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -20,5 +20,4 @@ jobs:
       pull-requests: write
       actions: read
     uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
-    timeout-minutes: 10
     secrets: inherit


### PR DESCRIPTION
## What

One or more jobs set a job-level `timeout-minutes:` on a job that calls a reusable workflow via `uses:`. GitHub does not permit that key on a `workflow_call` job, so it **rejected the file at parse time** — the workflow failed instantly (`0s`) on every push and never ran a single job.

## Fix

Remove the invalid caller-side `timeout-minutes:`. The standards `*-reusable.yml` workflows already declare `timeout-minutes` on every internal job, so the caller key was redundant as well as invalid.

## Verification

`actionlint` (real tool): no `timeout-minutes is not available` findings remain.

## Context

Estate-wide shared-fate CI defect across 84 repos. Reference fix: hyperpolymath/gitbot-fleet#374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)