### PR TITLE
fix(ci): repair dogfood-gate.yml — the workflow has never run

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -263,26 +263,26 @@ jobs:
 
           # Validate TOML structure using Python 3.11+ tomllib
           python3 -c "
-import tomllib, sys
-with open('eclexiaiser.toml', 'rb') as f:
-    data = tomllib.load(f)
-project = data.get('project', {})
-if not project.get('name', '').strip():
-    print('ERROR: project.name is required', file=sys.stderr)
-    sys.exit(1)
-functions = data.get('functions', [])
-if not functions:
-    print('ERROR: at least one [[functions]] entry is required', file=sys.stderr)
-    sys.exit(1)
-for fn in functions:
-    if not fn.get('name', '').strip():
-        print('ERROR: function name cannot be empty', file=sys.stderr)
-        sys.exit(1)
-    if not fn.get('source', '').strip():
-        print(f'ERROR: function {fn[\"name\"]} has no source path', file=sys.stderr)
-        sys.exit(1)
-print(f'Valid: {project[\"name\"]} ({len(functions)} function(s))')
-" || {
+          import tomllib, sys
+          with open('eclexiaiser.toml', 'rb') as f:
+              data = tomllib.load(f)
+          project = data.get('project', {})
+          if not project.get('name', '').strip():
+              print('ERROR: project.name is required', file=sys.stderr)
+              sys.exit(1)
+          functions = data.get('functions', [])
+          if not functions:
+              print('ERROR: at least one [[functions]] entry is required', file=sys.stderr)
+              sys.exit(1)
+          for fn in functions:
+              if not fn.get('name', '').strip():
+                  print('ERROR: function name cannot be empty', file=sys.stderr)
+                  sys.exit(1)
+              if not fn.get('source', '').strip():
+                  print(f'ERROR: function {fn[\"name\"]} has no source path', file=sys.stderr)
+                  sys.exit(1)
+          print(f'Valid: {project[\"name\"]} ({len(functions)} function(s))')
+          " || {
             echo "::error file=eclexiaiser.toml::Invalid eclexiaiser.toml — see step output for details"
             exit 1
           }


### PR DESCRIPTION
This workflow is **invalid YAML**, so GitHub refuses it at parse time. It produces **no run, no check-run, no annotation and no log** — not a red X, an **absence**. Nothing on a dashboard distinguishes *"this gate passed"* from *"this gate does not exist"*.

The tell: the Actions API reports the workflow's `name` as its **file path** instead of its `name:` — GitHub registers a file it cannot parse under its path.

```
name = ".github/workflows/dogfood-gate.yml"
path = ".github/workflows/dogfood-gate.yml"   <- name == path
```

## Cause

The embedded `python3 -c "` body starts at **column 0**:

```yaml
        run: |
          python3 -c "
import tomllib, sys          # <- column 0 ends the block scalar
```

A `run: |` literal block ends at the first non-empty line indented *less* than the block. The Python terminates it, and YAML then tries to parse `import tomllib, sys` as a mapping key — *"could not find expected `:`"*.

## Fix

Indent the embedded body and its closing quote to the block indent. **YAML strips that indent again when parsing**, so the shell and the interpreter still receive the code at column 0. The content is unchanged; only the YAML framing differs.

## Verified, not assumed

- the file parses and yields a `jobs:` mapping
- `bash -n` passes on the reconstructed run block
- the resulting `run:` value is **byte-identical** to the same workflow in repos where it already parses (e.g. `bofig`) — this reproduces the known-good form rather than inventing one
- **exactly one file changed**

## Scope

Measured estate-wide: **211 invalid workflow files across 116 repos**, confirmed by the Actions API. `dogfood-gate.yml` accounts for **71** of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)